### PR TITLE
App 컴포넌트에 Props 타입 정의

### DIFF
--- a/src/core/common/App.tsx
+++ b/src/core/common/App.tsx
@@ -6,7 +6,12 @@ const Wrapper = styled.div`
   width: 100%;
 `;
 
-export const App = (props: any) => {
+interface Props {
+  theme: object;
+  children?: any;
+}
+
+export const App = (props: Props) => {
   return (
     <ThemeProvider theme={props.theme}>
       <Wrapper>


### PR DESCRIPTION
ThemeProvider 에 테마가 정의되어 있지 않으면 런타임 에러가 발생하게 되는데, App 컴포넌트에 Props type이 any로 되어 있어 타입 정의를 통해 컴파일 타임에 알 수 있도록 개선